### PR TITLE
Replace find / cp with rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git:latest
 
-RUN apk add --no-cache bash findutils
+RUN apk add --no-cache bash rsync
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git:latest
 
-RUN apk add --no-cache bash rsync
+RUN apk add --no-cache bash rsync git
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 )
 
 debug "Syncing contents of $1 to repository"
-rsync -avzr --delete --exclude='.git/' "$1" "$tmp_dir"
+rsync -avzr --delete --exclude='.git/' "$1" "$tmp_dir" || exit 1
 
 debug "Committing and pushing changes"
 (

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,11 +50,8 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
     git pull "$GIT_REPOSITORY_URL"
 )
 
-debug "Enumerating contents of $1"
-for file in $(find $1 -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
-    debug "Copying $file"
-    cp "$1/$file" "$tmp_dir"
-done
+debug "Syncing contents of $1 to repository"
+rsync -avzr --delete --exclude='.git/' "$1" "$tmp_dir"
 
 debug "Committing and pushing changes"
 (


### PR DESCRIPTION
Resolves #2

`rsync` is more capable than the current approach of looping over `find` results and `cp`-ing files over. With this change, all files — not just ones ending in `.md` — are copied, and any existing files that aren't present in the specified `path` input are deleted.

It's unclear to me how the behavior of `rsync` would best be configured through the action interface. Among the options currently being considered:

- Conditionalizing the presence of only the `--delete` flag with a `delete` input argument.
- Allowing the user pass arbitrary options through an `rsync_options` input argument.