### PR TITLE
Set branding.color to white

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,4 +13,4 @@ runs:
 
 branding:
   icon: "book-open"
-  color: "black"
+  color: "white"


### PR DESCRIPTION
Fixes the following validation error in `action.yml`:

> Value is not accepted. Valid values: "white", "yellow", "blue", "green", "orange", "red", "purple", "gray-dark".
