### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ jobs:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 ```
 
-This workflow supports GitHub Enterprise automatically using the `GITHUB_SERVER_URL` envar.
-
 ## Setup
 
 This GitHub action requires that your repository has the following:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ jobs:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 ```
 
+### Supported Products
+
+- [x] GitHub.com
+- [x] GitHub Enterprise Cloud
+- [x] GitHub Enterprise Server 
+- [x] GitHub AE
+
 ## Setup
 
 This GitHub action requires that your repository has the following:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ jobs:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 ```
 
+This workflow supports GitHub Enterprise automatically using the `GITHUB_SERVER_URL` envar.
+
 ## Setup
 
 This GitHub action requires that your repository has the following:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ if [ -z "${WIKI_COMMIT_MESSAGE:-}" ]; then
     WIKI_COMMIT_MESSAGE='Automatically publish wiki'
 fi
 
-GIT_REPOSITORY_URL="https://${GH_PERSONAL_ACCESS_TOKEN}@github.com/$GITHUB_REPOSITORY.wiki.git"
+GIT_REPOSITORY_URL="https://${GH_PERSONAL_ACCESS_TOKEN}@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY.wiki.git"
 
 debug "Checking out wiki repository"
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)


### PR DESCRIPTION
This adds a `GITHUB_ENTERPRISE_DOMAIN` environment variable to allow for domains other than github.com.

I tested this on my company's GitHub Enterprise and it worked fine. 

Is V1 the proper base branch for this PR?